### PR TITLE
Relative mode feat

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -5,11 +5,16 @@
 /**
  * @brief Set to the exact amount of panels in the display. Never set it lower!!!
  */
-#define CFG_PANEL_COUNT 1
+#define CFG_PANEL_COUNT 4
 /**
  * @brief Set the byte polarity of the driver - 0 is normal, 1 is inverted
  */
 #define CFG_PIXEL_POLARITY 0
+
+/**
+ * @brief Enabling relative mode only updates the pixels that are different compared to the previous state
+ */
+#define CFG_RELATIVE_MODE 1
 
 //PIN DEFINITIONS
 

--- a/include/driver.h
+++ b/include/driver.h
@@ -51,6 +51,17 @@ void driver_getBuffer(uint8_t * data);
  */
 void driver_setBuffer(const uint8_t * data, uint8_t size);
 
+/**
+ * @brief Writes the content of the internal buffer onto the screen.
+ * When relative mode is used, stores the previous writeScreen data, and only writes the modified pixels onto the screen.
+ * 
+ */
 void driver_writeScreen();
+
+/**
+ * @brief In relative mode overrites the full screen with the given buffer data.
+ * 
+ */
+void driver_forceWriteScreen();
 
 #endif

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1,7 +1,9 @@
 #include "driver.h"
 #include "shiftRegister.h"
 
-#define _BIT_AT(COL, ROW) (_buffer[AT((COL)/8,(ROW))] & (0x80 >> ((COL)%8)))
+#define _BIT_AT(BUFFER, COL, ROW) (BUFFER[AT((COL)/8,(ROW))] & (0x80 >> ((COL)%8)))
+#define _BIT_AT_B(COL, ROW) (_BIT_AT(_buffer, COL, ROW))
+#define _BIT_AT_BPRV(COL, ROW) (_BIT_AT(_buffer_prev, COL, ROW))
 
 enum _DRV_ROW_CONTROL_MODE {
 	_DRV_ROW_CONTROL_MODE_SINK,
@@ -13,6 +15,7 @@ enum _DRV_ROW_CONTROL_MODE {
  * 
  */
 static uint8_t _buffer[DRV_DATABUFF_SIZE];
+static uint8_t _buffer_prev[DRV_DATABUFF_SIZE];
 
 static shiftReg_t _rowCntrlReg = {
 	.PIN_DATA			= CFG_ROW_CONTROL_DATA,
@@ -161,7 +164,7 @@ static void _driver_setRowControl(enum _DRV_ROW_CONTROL_MODE mode, uint8_t row, 
  * the drivers to flick the display pixel. For the reverse flick, we do the same thing, with different row data.
  */
 void driver_writeScreen() {
-
+	
 	for(uint8_t row = 0; row < DRV_ROW_COUNT; row++) {
 
 		for(uint8_t panel = 0; panel < CFG_PANEL_COUNT; panel++) {
@@ -170,14 +173,19 @@ void driver_writeScreen() {
 			
 			shiftReg_sendData(&_colCntrlReg, 0x01, 1); //Putting the first bit into the first shift register
 			//COL data setup SOURCE
-			for(uint8_t col = DRV_COL_COUNT; col > 0 ; col--) {
-				if(_BIT_AT(col-1+DRV_COL_COUNT*panel, row)) { //Current pin is set
-					shiftReg_latchData(&_colCntrlReg);
-					shiftReg_outputSet(&_rowCntrlReg, true);
-					digitalWrite(CFG_COL_CONTROL_OUTPUT_12V, CFG_COL_CONTROL_OUTPUT_12V_ON);
-					delay(1);
-					digitalWrite(CFG_COL_CONTROL_OUTPUT_12V, CFG_COL_CONTROL_OUTPUT_12V_OFF);
-					shiftReg_outputSet(&_rowCntrlReg, false);
+			for(uint8_t col = DRV_COL_COUNT; col > 0 ; col--) { //Current pin is set
+				uint16_t colIndx = col-1+DRV_COL_COUNT*panel;
+
+				if(_BIT_AT_B(colIndx, row) == 1){ //Bit is set
+					if((CFG_RELATIVE_MODE &&  (_BIT_AT_BPRV(colIndx, row) == 0)) || !CFG_RELATIVE_MODE) {
+
+						shiftReg_latchData(&_colCntrlReg);
+						shiftReg_outputSet(&_rowCntrlReg, true);
+						digitalWrite(CFG_COL_CONTROL_OUTPUT_12V, CFG_COL_CONTROL_OUTPUT_12V_ON);
+						delay(1);
+						shiftReg_outputSet(&_rowCntrlReg, false);
+						digitalWrite(CFG_COL_CONTROL_OUTPUT_12V, CFG_COL_CONTROL_OUTPUT_12V_OFF);
+					}				
 				}
 				shiftReg_shiftIn(&_colCntrlReg);
 			}
@@ -186,14 +194,17 @@ void driver_writeScreen() {
 			_driver_setRowControl(_DRV_ROW_CONTROL_MODE_SOURCE, row, panel);
 			//COL data setup SINK
 			for(uint8_t col = DRV_COL_COUNT; col > 0; col--) {
-				
-				if(_BIT_AT(col-1+DRV_COL_COUNT*panel, row) == 0) { //Current pin is not set
-					shiftReg_latchData(&_colCntrlReg);
-					shiftReg_outputSet(&_rowCntrlReg, true);
-					digitalWrite(CFG_COL_CONTROL_OUTPUT_GND, CFG_COL_CONTROL_OUTPUT_GND_ON);
-					delay(1);
-					digitalWrite(CFG_COL_CONTROL_OUTPUT_GND, CFG_COL_CONTROL_OUTPUT_GND_OFF);
-					shiftReg_outputSet(&_rowCntrlReg, false);
+				uint16_t colIndx = col-1+DRV_COL_COUNT*panel;
+
+				if(_BIT_AT_B(colIndx, row) == 0){ //Current pin is not set
+					if((CFG_RELATIVE_MODE && (_BIT_AT_BPRV(colIndx, row) == 1)) || !CFG_RELATIVE_MODE) { 
+						shiftReg_latchData(&_colCntrlReg);
+						shiftReg_outputSet(&_rowCntrlReg, true);
+						digitalWrite(CFG_COL_CONTROL_OUTPUT_GND, CFG_COL_CONTROL_OUTPUT_GND_ON);
+						delay(1);
+						digitalWrite(CFG_COL_CONTROL_OUTPUT_GND, CFG_COL_CONTROL_OUTPUT_GND_OFF);
+						shiftReg_outputSet(&_rowCntrlReg, false);
+					}
 				}
 				shiftReg_shiftIn(&_colCntrlReg);
 			}

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -12,7 +12,6 @@ enum _DRV_ROW_CONTROL_MODE {
 
 /**
  * @brief Stores the display data, in a checkboard compensated form.
- * 
  */
 static uint8_t _buffer[DRV_DATABUFF_SIZE];
 static uint8_t _buffer_prev[DRV_DATABUFF_SIZE];
@@ -176,7 +175,7 @@ void driver_writeScreen() {
 			for(uint8_t col = DRV_COL_COUNT; col > 0 ; col--) { //Current pin is set
 				uint16_t colIndx = col-1+DRV_COL_COUNT*panel;
 
-				if(_BIT_AT_B(colIndx, row) == 1){ //Bit is set
+				if(_BIT_AT_B(colIndx, row)){ //Bit is set
 					if((CFG_RELATIVE_MODE &&  (_BIT_AT_BPRV(colIndx, row) == 0)) || !CFG_RELATIVE_MODE) {
 
 						shiftReg_latchData(&_colCntrlReg);
@@ -197,7 +196,7 @@ void driver_writeScreen() {
 				uint16_t colIndx = col-1+DRV_COL_COUNT*panel;
 
 				if(_BIT_AT_B(colIndx, row) == 0){ //Current pin is not set
-					if((CFG_RELATIVE_MODE && (_BIT_AT_BPRV(colIndx, row) == 1)) || !CFG_RELATIVE_MODE) { 
+					if((CFG_RELATIVE_MODE && _BIT_AT_BPRV(colIndx, row)) || !CFG_RELATIVE_MODE) { 
 						shiftReg_latchData(&_colCntrlReg);
 						shiftReg_outputSet(&_rowCntrlReg, true);
 						digitalWrite(CFG_COL_CONTROL_OUTPUT_GND, CFG_COL_CONTROL_OUTPUT_GND_ON);
@@ -210,4 +209,14 @@ void driver_writeScreen() {
 			}
 		}
 	}
+	memcpy(_buffer_prev, _buffer, DRV_DATABUFF_SIZE);
+}
+
+void driver_forceWriteScreen() {
+	if(CFG_RELATIVE_MODE) {
+		for (size_t i = 0; i < DRV_DATABUFF_SIZE; i++) {
+			_buffer_prev[i] = ~_buffer[i];
+		}
+	}
+	driver_writeScreen();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,16 +5,20 @@
 #include "driver.h"
 #include "serialCom.h"
 
+uint8_t buff[DRV_DATABUFF_SIZE] = {0};
+
 void setup() {
     sCom_init(&Serial, 115200);
     driver_init();
+    memset(buff, 0, DRV_DATABUFF_SIZE);
+    driver_setBuffer(buff, DRV_DATABUFF_SIZE);
+    driver_forceWriteScreen();
 }
 
+
 void loop() {
-    uint8_t buff[DRV_DATABUFF_SIZE];
-    
     sCom_waitForData(buff, DRV_DATABUFF_SIZE);
-    
     driver_setBuffer(buff, DRV_DATABUFF_SIZE);
     driver_writeScreen();
+    Serial.println("print_finished");    
 }


### PR DESCRIPTION
Relative display mode added. Can be turned on or off in the config.h with the `#define CFG_RELATIVE_MODE` 
In relative display mode only the pixel differences are written directly to the screen, speeding up the framerate.
The controller sends a serial message when the display write is finished.